### PR TITLE
V2 pool rebalancing

### DIFF
--- a/stablecoin-v2/src/fees.rs
+++ b/stablecoin-v2/src/fees.rs
@@ -12,18 +12,19 @@ pub trait FeesModule:
         let coverage_ratio = self.get_coverage_ratio(collateral_id);
         let (min_fees_percentage, max_fees_percentage) =
             self.min_max_fees_percentage(collateral_id).get();
+        let one = BigUint::from(ONE);
 
         if coverage_ratio == 0 {
             return max_fees_percentage;
         }
-        if coverage_ratio >= ONE {
+        if coverage_ratio >= one {
             return min_fees_percentage;
         }
 
         let percentage_diff = &max_fees_percentage - &min_fees_percentage;
 
         // max - (max - min) * coverage_ratio
-        max_fees_percentage - self.multiply(&coverage_ratio, &percentage_diff)
+        max_fees_percentage - self.multiply(&coverage_ratio, &percentage_diff, &one)
     }
 
     // burn fees decrease as coverage ratio decreases
@@ -32,30 +33,37 @@ pub trait FeesModule:
         let coverage_ratio = self.get_coverage_ratio(collateral_id);
         let (min_fees_percentage, max_fees_percentage) =
             self.min_max_fees_percentage(collateral_id).get();
+        let one = BigUint::from(ONE);
 
         if coverage_ratio == 0 {
             return min_fees_percentage;
         }
-        if coverage_ratio >= ONE {
+        if coverage_ratio >= one {
             return max_fees_percentage;
         }
 
         let percentage_diff = &max_fees_percentage - &min_fees_percentage;
 
         // min + (max - min) * coverage_ratio
-        min_fees_percentage + self.multiply(&coverage_ratio, &percentage_diff)
+        min_fees_percentage + self.multiply(&coverage_ratio, &percentage_diff, &one)
     }
 
     // The more collateral is covered, the more expensive it is to open a position
     // This scales the same way as the burn transaction fees, so we use the same formula
     #[view(getHedgingPositionOpenTransactionFeesPercentage)]
-    fn get_hedging_position_open_transaction_fees_percentage(&self, collateral_id: &TokenIdentifier) -> BigUint {
+    fn get_hedging_position_open_transaction_fees_percentage(
+        &self,
+        collateral_id: &TokenIdentifier,
+    ) -> BigUint {
         self.get_burn_transaction_fees_percentage(collateral_id)
     }
 
     // The more collateral is covered, the less expensive it is to exit
     #[view(getHedgingPositionCloseTransactionFeesPercentage)]
-    fn get_hedging_position_close_transaction_fees_percentage(&self, collateral_id: &TokenIdentifier) -> BigUint {
+    fn get_hedging_position_close_transaction_fees_percentage(
+        &self,
+        collateral_id: &TokenIdentifier,
+    ) -> BigUint {
         self.get_mint_transaction_fees_percentage(collateral_id)
     }
 

--- a/stablecoin-v2/src/fees.rs
+++ b/stablecoin-v2/src/fees.rs
@@ -9,43 +9,45 @@ pub trait FeesModule:
     // mint fees decrease as coverage ratio increases
     #[view(getMintTransactionFeesPercentage)]
     fn get_mint_transaction_fees_percentage(&self, collateral_id: &TokenIdentifier) -> BigUint {
-        let coverage_ratio = self.get_coverage_ratio(collateral_id);
+        let target_hedging_ratio = self.target_hedging_ratio().get();
+        let current_hedging_ratio = self.calculate_current_hedging_ratio(collateral_id);
         let (min_fees_percentage, max_fees_percentage) =
             self.min_max_fees_percentage(collateral_id).get();
         let one = BigUint::from(ONE);
 
-        if coverage_ratio == 0 {
+        if current_hedging_ratio == 0 {
             return max_fees_percentage;
         }
-        if coverage_ratio >= one {
+        if current_hedging_ratio >= target_hedging_ratio {
             return min_fees_percentage;
         }
 
         let percentage_diff = &max_fees_percentage - &min_fees_percentage;
 
-        // max - (max - min) * coverage_ratio
-        max_fees_percentage - self.multiply(&coverage_ratio, &percentage_diff, &one)
+        // max - (max - min) * hedging_ratio
+        max_fees_percentage - self.multiply(&current_hedging_ratio, &percentage_diff, &one)
     }
 
     // burn fees decrease as coverage ratio decreases
     #[view(getBurnTransactionFeesPercentage)]
     fn get_burn_transaction_fees_percentage(&self, collateral_id: &TokenIdentifier) -> BigUint {
-        let coverage_ratio = self.get_coverage_ratio(collateral_id);
+        let target_hedging_ratio = self.target_hedging_ratio().get();
+        let current_hedging_ratio = self.calculate_current_hedging_ratio(collateral_id);
         let (min_fees_percentage, max_fees_percentage) =
             self.min_max_fees_percentage(collateral_id).get();
         let one = BigUint::from(ONE);
 
-        if coverage_ratio == 0 {
+        if current_hedging_ratio == 0 {
             return min_fees_percentage;
         }
-        if coverage_ratio >= one {
+        if current_hedging_ratio >= target_hedging_ratio {
             return max_fees_percentage;
         }
 
         let percentage_diff = &max_fees_percentage - &min_fees_percentage;
 
-        // min + (max - min) * coverage_ratio
-        min_fees_percentage + self.multiply(&coverage_ratio, &percentage_diff, &one)
+        // min + (max - min) * hedging_ratio
+        min_fees_percentage + self.multiply(&current_hedging_ratio, &percentage_diff, &one)
     }
 
     // The more collateral is covered, the more expensive it is to open a position
@@ -67,6 +69,28 @@ pub trait FeesModule:
         self.get_mint_transaction_fees_percentage(collateral_id)
     }
 
+    #[view(getCurrentHedgingRatio)]
+    fn calculate_current_hedging_ratio(&self, collateral_id: &TokenIdentifier) -> BigUint {
+        let pool = self.get_pool(collateral_id);
+        let target_hedge_amount = self.calculate_target_hedge_amount(&pool.collateral_amount);
+        self.calculate_ratio(
+            &pool.total_covered_value_in_stablecoin,
+            &target_hedge_amount,
+        )
+    }
+
+    #[view(getTargetHedgeAmount)]
+    fn calculate_target_hedge_amount(&self, collateral_amount: &BigUint) -> BigUint {
+        let target_hedging_ratio = self.target_hedging_ratio().get();
+        self.calculate_percentage_of(&target_hedging_ratio, collateral_amount)
+    }
+
+    #[view(getLimitHedgeAmount)]
+    fn calculate_limit_hedge_amount(&self, collateral_amount: &BigUint) -> BigUint {
+        let hedging_ratio_limit = self.hedging_ratio_limit().get();
+        self.calculate_percentage_of(&hedging_ratio_limit, collateral_amount)
+    }
+
     // storage
 
     #[storage_mapper("minMaxFeesPercentage")]
@@ -79,4 +103,12 @@ pub trait FeesModule:
     // These fees will go to the liquidity providers
     #[storage_mapper("accumulatedTxFees")]
     fn accumulated_tx_fees(&self, collateral_id: &TokenIdentifier) -> SingleValueMapper<BigUint>;
+
+    #[view(getTargetHedgingRatio)]
+    #[storage_mapper("targetHedgingRatio")]
+    fn target_hedging_ratio(&self) -> SingleValueMapper<BigUint>;
+
+    #[view(getHedgingRatioLimit)]
+    #[storage_mapper("hedgingRatioLimit")]
+    fn hedging_ratio_limit(&self) -> SingleValueMapper<BigUint>;
 }

--- a/stablecoin-v2/src/hedging_agents.rs
+++ b/stablecoin-v2/src/hedging_agents.rs
@@ -13,6 +13,12 @@ pub struct HedgingPosition<M: ManagedTypeApi> {
     pub withdraw_amount_after_force_close: Option<BigUint<M>>,
 }
 
+impl<M: ManagedTypeApi> HedgingPosition<M> {
+    pub fn is_closed(&self) -> bool {
+        self.withdraw_amount_after_force_close.is_some()
+    }
+}
+
 #[elrond_wasm::module]
 pub trait HedgingAgentsModule:
     crate::fees::FeesModule
@@ -39,11 +45,25 @@ pub trait HedgingAgentsModule:
         );
 
         let mut pool = self.get_pool(&payment_token);
+        let target_hedge_amount = self.calculate_target_hedge_amount(&pool.collateral_amount);
+        require!(
+            pool.total_collateral_covered <= target_hedge_amount,
+            "Over target hedge amount, no new positions may be opened"
+        );
+
         pool.total_collateral_covered += &amount_to_cover;
         require!(
             pool.total_collateral_covered <= pool.collateral_amount,
             "Trying to cover too much collateral"
         );
+        require!(
+            pool.total_collateral_covered <= target_hedge_amount,
+            "Position would go over target hedge amount"
+        );
+
+        let amount_to_cover_in_stablecoin =
+            self.multiply(&collateral_value_in_dollars, &amount_to_cover);
+        pool.total_covered_value_in_stablecoin += amount_to_cover_in_stablecoin;
 
         let transaction_fees_percentage =
             self.get_hedging_position_open_transaction_fees_percentage(&payment_token);
@@ -51,9 +71,15 @@ pub trait HedgingAgentsModule:
             self.calculate_percentage_of(&transaction_fees_percentage, &payment_amount);
         let collateral_amount = &payment_amount - &fees_amount_in_collateral;
 
-        let max_leverage = self.max_leverage(&payment_token).get();
-        let position_leverage = self.calculate_leverage(&collateral_amount, &amount_to_cover);
-        require!(position_leverage <= max_leverage, "Leverage too high");
+        let hedging_position = HedgingPosition {
+            collateral_id: payment_token.clone(),
+            deposit_amount: collateral_amount,
+            covered_amount: amount_to_cover,
+            oracle_value_at_deposit_time: collateral_value_in_dollars,
+            creation_timestamp: self.blockchain().get_block_timestamp(),
+            withdraw_amount_after_force_close: None,
+        };
+        self.require_under_max_leverage(&hedging_position)?;
 
         self.accumulated_tx_fees(&payment_token)
             .update(|accumulated_fees| *accumulated_fees += fees_amount_in_collateral);
@@ -64,14 +90,82 @@ pub trait HedgingAgentsModule:
         pool.hedging_positions.push(nft_nonce);
 
         self.set_pool(&payment_token, &pool);
-        self.hedging_position(nft_nonce).set(&HedgingPosition {
-            collateral_id: payment_token,
-            deposit_amount: collateral_amount,
-            covered_amount: amount_to_cover,
-            oracle_value_at_deposit_time: collateral_value_in_dollars,
-            creation_timestamp: self.blockchain().get_block_timestamp(),
-            withdraw_amount_after_force_close: None,
-        });
+        self.hedging_position(nft_nonce).set(&hedging_position);
+
+        Ok(())
+    }
+
+    #[payable("*")]
+    #[endpoint(addMargin)]
+    fn add_margin(&self) -> SCResult<()> {
+        let nr_required_transfers = 2;
+        let transfers: Vec<EsdtTokenPayment<Self::Api>> =
+            self.call_value().all_esdt_transfers().into_iter().collect();
+        require!(
+            transfers.len() == nr_required_transfers,
+            "Invalid number of transfers"
+        );
+
+        let first_transfer = &transfers[0];
+        let second_transfer = &transfers[1];
+
+        let hedging_token_id = self.hedging_token_id().get();
+        require!(
+            first_transfer.token_identifier == hedging_token_id,
+            "First token should be the hedging NFT"
+        );
+
+        let nft_nonce = first_transfer.token_nonce;
+        self.hedging_position(nft_nonce).update(|hedging_pos| {
+            require!(
+                second_transfer.token_identifier == hedging_pos.collateral_id,
+                "Second token should be the collateral for the position"
+            );
+            self.require_not_closed(hedging_pos)?;
+
+            hedging_pos.deposit_amount += &second_transfer.amount;
+            self.require_under_max_leverage(hedging_pos)?;
+
+            Ok(())
+        })?;
+
+        // return the nft
+        let caller = self.blockchain().get_caller();
+        self.send_hedging_token(&caller, nft_nonce);
+
+        Ok(())
+    }
+
+    #[payable("*")]
+    #[endpoint(removeMargin)]
+    fn remove_margin(
+        &self,
+        #[payment_token] payment_token: TokenIdentifier,
+        #[payment_nonce] payment_nonce: u64,
+        amount_to_remove: BigUint,
+    ) -> SCResult<()> {
+        let hedging_token_id = self.hedging_token_id().get();
+        require!(
+            payment_token == hedging_token_id,
+            "Token should be the hedging NFT"
+        );
+
+        self.hedging_position(payment_nonce).update(|hedging_pos| {
+            require!(
+                amount_to_remove < hedging_pos.deposit_amount,
+                "Remove amount higher than total deposit"
+            );
+            self.require_not_closed(hedging_pos)?;
+
+            hedging_pos.deposit_amount -= &amount_to_remove;
+            self.require_under_max_leverage(hedging_pos)?;
+
+            Ok(())
+        })?;
+
+        // return the nft
+        let caller = self.blockchain().get_caller();
+        self.send_hedging_token(&caller, payment_nonce);
 
         Ok(())
     }
@@ -115,33 +209,7 @@ pub trait HedgingAgentsModule:
         Ok(())
     }
 
-    #[endpoint(forceCloseHedgingPosition)]
-    fn force_close_hedging_position(&self, nft_nonce: u64) -> SCResult<()> {
-        let mut hedging_position = self.hedging_position(nft_nonce).get();
-        let coverage_ratio = self.get_coverage_ratio(&hedging_position.collateral_id);
-        require!(
-            coverage_ratio > ONE,
-            "Coverage ratio not high enough to force close"
-        );
-
-        hedging_position.withdraw_amount_after_force_close =
-            Some(self.close_position(nft_nonce, &hedging_position, None)?);
-
-        self.hedging_position(nft_nonce).set(&hedging_position);
-
-        Ok(())
-    }
-
     // private
-
-    #[inline(always)]
-    fn calculate_leverage(
-        &self,
-        collateral_amount: &BigUint,
-        amount_to_cover: &BigUint,
-    ) -> BigUint {
-        self.calculate_ratio(&(collateral_amount + amount_to_cover), amount_to_cover)
-    }
 
     // deduplicates code for close and force-close
     fn close_position(
@@ -150,6 +218,8 @@ pub trait HedgingAgentsModule:
         hedging_position: &HedgingPosition<Self::Api>,
         opt_min_oracle_value: Option<BigUint>,
     ) -> SCResult<BigUint> {
+        self.require_not_closed(hedging_position)?;
+
         let mut pool = self.get_pool(&hedging_position.collateral_id);
 
         let current_time = self.blockchain().get_block_timestamp();
@@ -207,9 +277,55 @@ pub trait HedgingAgentsModule:
             .ok_or("Could not close position")?;
         let _ = pool.hedging_positions.swap_remove(pos_index);
 
+        let amount_to_cover_in_stablecoin = self.multiply(
+            &hedging_position.oracle_value_at_deposit_time,
+            &hedging_position.covered_amount,
+        );
+        pool.total_covered_value_in_stablecoin -= amount_to_cover_in_stablecoin;
+
         self.set_pool(&hedging_position.collateral_id, &pool);
 
         Ok(withdraw_amount)
+    }
+
+    #[inline(always)]
+    fn calculate_leverage(
+        &self,
+        collateral_amount: &BigUint,
+        amount_to_cover: &BigUint,
+    ) -> BigUint {
+        self.calculate_ratio(&(collateral_amount + amount_to_cover), collateral_amount)
+    }
+
+    #[inline(always)]
+    fn calculate_target_hedge_amount(&self, collateral_amount: &BigUint) -> BigUint {
+        let target_hedging_ratio = self.target_hedging_ratio().get();
+        self.calculate_percentage_of(&target_hedging_ratio, collateral_amount)
+    }
+
+    #[inline(always)]
+    fn calculate_limit_hedge_amount(&self, collateral_amount: &BigUint) -> BigUint {
+        let hedging_ratio_limit = self.hedging_ratio_limit().get();
+        self.calculate_percentage_of(&hedging_ratio_limit, collateral_amount)
+    }
+
+    fn require_under_max_leverage(
+        &self,
+        hedging_position: &HedgingPosition<Self::Api>,
+    ) -> SCResult<()> {
+        let max_leverage = self.max_leverage(&hedging_position.collateral_id).get();
+        let position_leverage = self.calculate_leverage(
+            &hedging_position.deposit_amount,
+            &hedging_position.covered_amount,
+        );
+        require!(position_leverage <= max_leverage, "Leverage too high");
+
+        Ok(())
+    }
+
+    fn require_not_closed(&self, hedging_position: &HedgingPosition<Self::Api>) -> SCResult<()> {
+        require!(!hedging_position.is_closed(), "Position already closed");
+        Ok(())
     }
 
     // storage
@@ -220,4 +336,12 @@ pub trait HedgingAgentsModule:
     #[view(getMinHedgingPeriodSeconds)]
     #[storage_mapper("minHedgingPeriodSeconds")]
     fn min_hedging_period_seconds(&self) -> SingleValueMapper<u64>;
+
+    #[view(getTargetHedgingRatio)]
+    #[storage_mapper("targetHedgingRatio")]
+    fn target_hedging_ratio(&self) -> SingleValueMapper<BigUint>;
+
+    #[view(getHedgingRatioLimit)]
+    #[storage_mapper("hedgingRatioLimit")]
+    fn hedging_ratio_limit(&self) -> SingleValueMapper<BigUint>;
 }

--- a/stablecoin-v2/src/hedging_agents.rs
+++ b/stablecoin-v2/src/hedging_agents.rs
@@ -19,6 +19,7 @@ pub struct HedgingPosition<M: ManagedTypeApi> {
 }
 
 impl<M: ManagedTypeApi> HedgingPosition<M> {
+    #[inline(always)]
     pub fn is_closed(&self) -> bool {
         self.withdraw_amount_after_force_close.is_some()
     }

--- a/stablecoin-v2/src/hedging_agents.rs
+++ b/stablecoin-v2/src/hedging_agents.rs
@@ -349,18 +349,6 @@ pub trait HedgingAgentsModule:
         self.calculate_ratio(&(collateral_amount + amount_to_cover), collateral_amount)
     }
 
-    #[inline(always)]
-    fn calculate_target_hedge_amount(&self, collateral_amount: &BigUint) -> BigUint {
-        let target_hedging_ratio = self.target_hedging_ratio().get();
-        self.calculate_percentage_of(&target_hedging_ratio, collateral_amount)
-    }
-
-    #[inline(always)]
-    fn calculate_limit_hedge_amount(&self, collateral_amount: &BigUint) -> BigUint {
-        let hedging_ratio_limit = self.hedging_ratio_limit().get();
-        self.calculate_percentage_of(&hedging_ratio_limit, collateral_amount)
-    }
-
     fn require_under_max_leverage(
         &self,
         hedging_position: &HedgingPosition<Self::Api>,
@@ -400,14 +388,6 @@ pub trait HedgingAgentsModule:
     #[view(getMaxLeverage)]
     #[storage_mapper("maxLeverage")]
     fn max_leverage(&self, collateral_id: &TokenIdentifier) -> SingleValueMapper<BigUint>;
-
-    #[view(getTargetHedgingRatio)]
-    #[storage_mapper("targetHedgingRatio")]
-    fn target_hedging_ratio(&self) -> SingleValueMapper<BigUint>;
-
-    #[view(getHedgingRatioLimit)]
-    #[storage_mapper("hedgingRatioLimit")]
-    fn hedging_ratio_limit(&self) -> SingleValueMapper<BigUint>;
 
     #[view(getHedgingMaintenanceRatio)]
     #[storage_mapper("hedgingMaintenanceRatio")]

--- a/stablecoin-v2/src/hedging_token.rs
+++ b/stablecoin-v2/src/hedging_token.rs
@@ -54,7 +54,7 @@ pub trait HedgingTokenModule {
             .async_call()
     }
 
-    fn create_and_send_hedging_token(&self, to: &ManagedAddress) -> u64 {
+    fn create_hedging_token(&self) -> u64 {
         let token_id = self.hedging_token_id().get();
         let amount = BigUint::from(NFT_AMOUNT);
         let mut uris = ManagedVec::new();
@@ -69,7 +69,6 @@ pub trait HedgingTokenModule {
             &(),
             &uris,
         );
-        self.send().direct(to, &token_id, nft_nonce, &amount, &[]);
 
         nft_nonce
     }

--- a/stablecoin-v2/src/hedging_token.rs
+++ b/stablecoin-v2/src/hedging_token.rs
@@ -2,7 +2,7 @@ elrond_wasm::imports!();
 
 const HEDGING_TOKEN_NAME: &[u8] = b"HedgingToken";
 const HEDGING_TOKEN_TICKER: &[u8] = b"HEDGE";
-const NFT_AMOUNT: u32 = 1;
+pub const NFT_AMOUNT: u32 = 1;
 
 #[elrond_wasm::module]
 pub trait HedgingTokenModule {
@@ -67,12 +67,18 @@ pub trait HedgingTokenModule {
             &BigUint::zero(),
             &ManagedBuffer::new(),
             &(),
-            &uris
+            &uris,
         );
-        self.send()
-            .direct(to, &token_id, nft_nonce, &amount, &[]);
+        self.send().direct(to, &token_id, nft_nonce, &amount, &[]);
 
         nft_nonce
+    }
+
+    fn send_hedging_token(&self, to: &ManagedAddress, nft_nonce: u64) {
+        let token_id = self.hedging_token_id().get();
+        let amount = BigUint::from(NFT_AMOUNT);
+
+        self.send().direct(to, &token_id, nft_nonce, &amount, &[]);
     }
 
     fn burn_hedging_token(&self, nft_nonce: u64) {

--- a/stablecoin-v2/src/keepers.rs
+++ b/stablecoin-v2/src/keepers.rs
@@ -1,0 +1,35 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait KeepersModule:
+    crate::fees::FeesModule
+    + crate::hedging_agents::HedgingAgentsModule
+    + crate::hedging_token::HedgingTokenModule
+    + crate::math::MathModule
+    + crate::pools::PoolsModule
+    + price_aggregator_proxy::PriceAggregatorModule
+{
+    #[endpoint(forceCloseHedgingPosition)]
+    fn force_close_hedging_position(&self, nft_nonce: u64) -> SCResult<()> {
+        let mut hedging_position = self.hedging_position(nft_nonce).get();
+        let pool = self.get_pool(&hedging_position.collateral_id);
+
+        let limit_hedge_amount = self.calculate_limit_hedge_amount(&pool.collateral_amount);
+        require!(
+            pool.total_covered_value_in_stablecoin > limit_hedge_amount,
+            "May only force close after limit hedge amount is passed"
+        );
+
+        hedging_position.withdraw_amount_after_force_close =
+            Some(self.close_position(nft_nonce, &hedging_position, None)?);
+
+        self.hedging_position(nft_nonce).set(&hedging_position);
+
+        Ok(())
+    }
+
+    #[endpoint(rebalancePool)]
+    fn rebalance_pool(&self, _collateral_id: TokenIdentifier) -> SCResult<()> {
+        Ok(())
+    }
+}

--- a/stablecoin-v2/src/keepers.rs
+++ b/stablecoin-v2/src/keepers.rs
@@ -1,5 +1,7 @@
 elrond_wasm::imports!();
 
+use crate::{hedging_agents::HedgingPosition, math::ONE};
+
 #[elrond_wasm::module]
 pub trait KeepersModule:
     crate::fees::FeesModule
@@ -11,6 +13,8 @@ pub trait KeepersModule:
 {
     #[endpoint(forceCloseHedgingPosition)]
     fn force_close_hedging_position(&self, nft_nonce: u64) -> SCResult<()> {
+        self.require_not_liquidated(nft_nonce)?;
+
         let mut hedging_position = self.hedging_position(nft_nonce).get();
         let pool = self.get_pool(&hedging_position.collateral_id);
 
@@ -20,10 +24,34 @@ pub trait KeepersModule:
             "May only force close after limit hedge amount is passed"
         );
 
+        self.close_position(nft_nonce, &hedging_position)?;
         hedging_position.withdraw_amount_after_force_close =
-            Some(self.close_position(nft_nonce, &hedging_position, None)?);
+            Some(self.get_withdraw_amount_and_update_fees(&hedging_position, None)?);
 
         self.hedging_position(nft_nonce).set(&hedging_position);
+
+        Ok(())
+    }
+
+    #[endpoint(liquidateHedgingPosition)]
+    fn liquidate_hedging_position(&self, nft_nonce: u64) -> SCResult<()> {
+        self.require_not_liquidated(nft_nonce)?;
+
+        let hedging_position = self.hedging_position(nft_nonce).get();
+        self.require_not_closed(&hedging_position)?;
+
+        let margin_ratio = self.calculate_margin_ratio(&hedging_position)?;
+        let hedging_maintenance_ratio = self.hedging_maintenance_ratio().get();
+        require!(
+            margin_ratio <= hedging_maintenance_ratio,
+            "Can only liquidate if margin ratio is below expected amount"
+        );
+
+        self.update_pool(&hedging_position.collateral_id, |pool| {
+            pool.collateral_amount += &hedging_position.deposit_amount
+        });
+        self.close_position(nft_nonce, &hedging_position)?;
+        self.hedging_position(nft_nonce).clear();
 
         Ok(())
     }
@@ -31,5 +59,35 @@ pub trait KeepersModule:
     #[endpoint(rebalancePool)]
     fn rebalance_pool(&self, _collateral_id: TokenIdentifier) -> SCResult<()> {
         Ok(())
+    }
+
+    fn calculate_margin_ratio(
+        &self,
+        hedging_position: &HedgingPosition<Self::Api>,
+    ) -> SCResult<BigUint> {
+        let collateral_value_in_dollars =
+            self.get_collateral_value_in_dollars(&hedging_position.collateral_id)?;
+
+        // margin = x / y + (1 - initial_oracle / current_oracle)
+        // where x is deposit_amount and y is amount_to_cover
+        let amount_ratio = self.calculate_ratio(
+            &hedging_position.deposit_amount,
+            &hedging_position.covered_amount,
+        );
+        let price_ratio = self.calculate_ratio(
+            &hedging_position.oracle_value_at_deposit_time,
+            &collateral_value_in_dollars,
+        );
+
+        let one = BigUint::from(ONE);
+        let result = if price_ratio <= one {
+            let diff = one - price_ratio;
+            amount_ratio + diff
+        } else {
+            let diff = price_ratio - one;
+            amount_ratio - diff
+        };
+
+        Ok(result)
     }
 }

--- a/stablecoin-v2/src/lib.rs
+++ b/stablecoin-v2/src/lib.rs
@@ -11,6 +11,9 @@ mod math;
 mod pools;
 mod stablecoin_token;
 
+// TODO: Check pool collateral values before subtracting, give other tokens instead for leftover amounts
+// TODO: Add events
+
 #[elrond_wasm::contract]
 pub trait StablecoinV2:
     fees::FeesModule
@@ -29,7 +32,6 @@ pub trait StablecoinV2:
         min_hedging_period_seconds: u64,
         target_hedging_ratio: BigUint,
         hedging_ratio_limit: BigUint,
-        hedging_maintenance_ratio: BigUint,
     ) -> SCResult<()> {
         require!(
             self.blockchain()
@@ -44,8 +46,6 @@ pub trait StablecoinV2:
             .set(&min_hedging_period_seconds);
         self.target_hedging_ratio().set(&target_hedging_ratio);
         self.hedging_ratio_limit().set(&hedging_ratio_limit);
-        self.hedging_maintenance_ratio()
-            .set(&hedging_maintenance_ratio);
 
         Ok(())
     }
@@ -61,6 +61,7 @@ pub trait StablecoinV2:
         max_leverage: BigUint,
         min_fees_percentage: BigUint,
         max_fees_percentage: BigUint,
+        hedging_maintenance_ratio: BigUint,
     ) -> SCResult<()> {
         require!(
             min_fees_percentage <= max_fees_percentage
@@ -73,6 +74,8 @@ pub trait StablecoinV2:
         self.max_leverage(&collateral_id).set(&max_leverage);
         self.min_max_fees_percentage(&collateral_id)
             .set(&(min_fees_percentage, max_fees_percentage));
+        self.hedging_maintenance_ratio(&collateral_id)
+            .set(&hedging_maintenance_ratio);
         let _ = self.collateral_whitelist().insert(collateral_id);
 
         Ok(())
@@ -84,6 +87,7 @@ pub trait StablecoinV2:
         self.collateral_ticker(&collateral_id).clear();
         self.max_leverage(&collateral_id).clear();
         self.min_max_fees_percentage(&collateral_id).clear();
+        self.hedging_maintenance_ratio(&collateral_id).clear();
         let _ = self.collateral_whitelist().remove(&collateral_id);
     }
 

--- a/stablecoin-v2/src/lib.rs
+++ b/stablecoin-v2/src/lib.rs
@@ -79,7 +79,7 @@ pub trait StablecoinV2:
             .set(&(min_fees_percentage, max_fees_percentage));
         self.hedging_maintenance_ratio(&collateral_id)
             .set(&hedging_maintenance_ratio);
-        let _ = self.collateral_whitelist().insert(collateral_id);
+        self.collateral_whitelisted(&collateral_id).set(&true);
 
         Ok(())
     }
@@ -92,7 +92,7 @@ pub trait StablecoinV2:
         self.max_leverage(&collateral_id).clear();
         self.min_max_fees_percentage(&collateral_id).clear();
         self.hedging_maintenance_ratio(&collateral_id).clear();
-        let _ = self.collateral_whitelist().remove(&collateral_id);
+        self.collateral_whitelisted(&collateral_id).clear();
     }
 
     // endpoints

--- a/stablecoin-v2/src/lib.rs
+++ b/stablecoin-v2/src/lib.rs
@@ -6,6 +6,7 @@ elrond_wasm::derive_imports!();
 mod fees;
 mod hedging_agents;
 mod hedging_token;
+mod keepers;
 mod math;
 mod pools;
 mod stablecoin_token;
@@ -15,6 +16,7 @@ pub trait StablecoinV2:
     fees::FeesModule
     + hedging_agents::HedgingAgentsModule
     + hedging_token::HedgingTokenModule
+    + keepers::KeepersModule
     + math::MathModule
     + pools::PoolsModule
     + price_aggregator_proxy::PriceAggregatorModule
@@ -25,6 +27,8 @@ pub trait StablecoinV2:
         &self,
         price_aggregator_address: ManagedAddress,
         min_hedging_period_seconds: u64,
+        target_hedging_ratio: BigUint,
+        hedging_ratio_limit: BigUint,
     ) -> SCResult<()> {
         require!(
             self.blockchain()
@@ -37,6 +41,8 @@ pub trait StablecoinV2:
 
         self.min_hedging_period_seconds()
             .set(&min_hedging_period_seconds);
+        self.target_hedging_ratio().set(&target_hedging_ratio);
+        self.hedging_ratio_limit().set(&hedging_ratio_limit);
 
         Ok(())
     }

--- a/stablecoin-v2/src/lib.rs
+++ b/stablecoin-v2/src/lib.rs
@@ -29,6 +29,7 @@ pub trait StablecoinV2:
         min_hedging_period_seconds: u64,
         target_hedging_ratio: BigUint,
         hedging_ratio_limit: BigUint,
+        hedging_maintenance_ratio: BigUint,
     ) -> SCResult<()> {
         require!(
             self.blockchain()
@@ -43,6 +44,8 @@ pub trait StablecoinV2:
             .set(&min_hedging_period_seconds);
         self.target_hedging_ratio().set(&target_hedging_ratio);
         self.hedging_ratio_limit().set(&hedging_ratio_limit);
+        self.hedging_maintenance_ratio()
+            .set(&hedging_maintenance_ratio);
 
         Ok(())
     }

--- a/stablecoin-v2/src/lib.rs
+++ b/stablecoin-v2/src/lib.rs
@@ -58,6 +58,7 @@ pub trait StablecoinV2:
         &self,
         collateral_id: TokenIdentifier,
         collateral_ticker: ManagedBuffer,
+        collateral_num_decimals: u32,
         max_leverage: BigUint,
         min_fees_percentage: BigUint,
         max_fees_percentage: BigUint,
@@ -71,6 +72,8 @@ pub trait StablecoinV2:
 
         self.collateral_ticker(&collateral_id)
             .set(&collateral_ticker);
+        self.collateral_num_decimals(&collateral_id)
+            .set(&collateral_num_decimals);
         self.max_leverage(&collateral_id).set(&max_leverage);
         self.min_max_fees_percentage(&collateral_id)
             .set(&(min_fees_percentage, max_fees_percentage));
@@ -85,6 +88,7 @@ pub trait StablecoinV2:
     #[endpoint(removeCollateralFromWhitelist)]
     fn remove_collateral_from_whitelist(&self, collateral_id: TokenIdentifier) {
         self.collateral_ticker(&collateral_id).clear();
+        self.collateral_num_decimals(&collateral_id).clear();
         self.max_leverage(&collateral_id).clear();
         self.min_max_fees_percentage(&collateral_id).clear();
         self.hedging_maintenance_ratio(&collateral_id).clear();

--- a/stablecoin-v2/src/math.rs
+++ b/stablecoin-v2/src/math.rs
@@ -6,8 +6,8 @@ pub const ONE: u64 = PERCENTAGE_PRECISION / 100;
 #[elrond_wasm::module]
 pub trait MathModule {
     #[inline(always)]
-    fn multiply(&self, first: &BigUint, second: &BigUint) -> BigUint {
-        first * second / ONE
+    fn multiply(&self, first: &BigUint, second: &BigUint, precision_to_remove: &BigUint) -> BigUint {
+        first * second / precision_to_remove
     }
 
     #[inline(always)]
@@ -18,5 +18,11 @@ pub trait MathModule {
     #[inline(always)]
     fn calculate_percentage_of(&self, percentage: &BigUint, number: &BigUint) -> BigUint {
         number * percentage / PERCENTAGE_PRECISION
+    }
+
+    #[inline(always)]
+    fn create_precision_biguint(&self, nr_decimals: u32) -> BigUint {
+        let base = BigUint::from(10u64);
+        base.pow(nr_decimals)
     }
 }

--- a/stablecoin-v2/src/math.rs
+++ b/stablecoin-v2/src/math.rs
@@ -3,6 +3,10 @@ elrond_wasm::imports!();
 pub const PERCENTAGE_PRECISION: u64 = 1_000_000_000; // 100%
 pub const ONE: u64 = PERCENTAGE_PRECISION / 100;
 
+// this is the most common case, and it's more efficient to have a constant instead of manually calculating 10^18 everytime
+const DEFAULT_TOKEN_NUM_DECIMALS: u32 = 18;
+const DEFAULT_TOKEN_DECIMALS_VALUE: u64 = 1_000_000_000_000_000_000;
+
 #[elrond_wasm::module]
 pub trait MathModule {
     #[inline(always)]
@@ -20,8 +24,11 @@ pub trait MathModule {
         number * percentage / PERCENTAGE_PRECISION
     }
 
-    #[inline(always)]
     fn create_precision_biguint(&self, nr_decimals: u32) -> BigUint {
+        if nr_decimals == DEFAULT_TOKEN_NUM_DECIMALS {
+            return BigUint::from(DEFAULT_TOKEN_DECIMALS_VALUE);
+        }
+
         let base = BigUint::from(10u64);
         base.pow(nr_decimals)
     }

--- a/stablecoin-v2/src/pools.rs
+++ b/stablecoin-v2/src/pools.rs
@@ -9,9 +9,6 @@ pub struct Pool<M: ManagedTypeApi> {
     pub stablecoin_amount: BigUint<M>,
     pub total_collateral_covered: BigUint<M>,
     pub total_covered_value_in_stablecoin: BigUint<M>,
-    pub hedging_agents_profit: BigUint<M>, // TODO: Update to contain the extra collateral after pool rebalancing,
-    // used to pay out rewards to hedging agents on close position
-    pub hedging_positions: Vec<u64>,
 }
 
 impl<M: ManagedTypeApi> Pool<M> {
@@ -21,8 +18,6 @@ impl<M: ManagedTypeApi> Pool<M> {
             stablecoin_amount: BigUint::zero(api.clone()),
             total_collateral_covered: BigUint::zero(api.clone()),
             total_covered_value_in_stablecoin: BigUint::zero(api.clone()),
-            hedging_agents_profit: BigUint::zero(api),
-            hedging_positions: Vec::new(),
         }
     }
 }
@@ -104,10 +99,6 @@ pub trait PoolsModule:
         &self,
         collateral_id: &TokenIdentifier,
     ) -> SingleValueMapper<ManagedBuffer>;
-
-    #[view(getMaxLeverage)]
-    #[storage_mapper("maxLeverage")]
-    fn max_leverage(&self, collateral_id: &TokenIdentifier) -> SingleValueMapper<BigUint>;
 
     #[view(getPoolForCollateral)]
     #[storage_mapper("poolForCollateral")]

--- a/stablecoin-v2/src/pools.rs
+++ b/stablecoin-v2/src/pools.rs
@@ -79,6 +79,11 @@ pub trait PoolsModule:
             .into()
     }
 
+    fn get_collateral_precision(&self, collateral_id: &TokenIdentifier) -> BigUint {
+        let collateral_num_decimals = self.collateral_num_decimals(collateral_id).get();
+        self.create_precision_biguint(collateral_num_decimals)
+    }
+
     fn require_collateral_in_whitelist(&self, collateral_id: &TokenIdentifier) -> SCResult<()> {
         require!(
             self.collateral_whitelist().contains(collateral_id),
@@ -99,6 +104,9 @@ pub trait PoolsModule:
         &self,
         collateral_id: &TokenIdentifier,
     ) -> SingleValueMapper<ManagedBuffer>;
+
+    #[storage_mapper("collateralNumDecimals")]
+    fn collateral_num_decimals(&self, collateral_id: &TokenIdentifier) -> SingleValueMapper<u32>;
 
     #[view(getPoolForCollateral)]
     #[storage_mapper("poolForCollateral")]

--- a/stablecoin-v2/src/pools.rs
+++ b/stablecoin-v2/src/pools.rs
@@ -8,6 +8,7 @@ pub struct Pool<M: ManagedTypeApi> {
     pub collateral_amount: BigUint<M>,
     pub stablecoin_amount: BigUint<M>,
     pub total_collateral_covered: BigUint<M>,
+    pub total_covered_value_in_stablecoin: BigUint<M>,
     pub hedging_agents_profit: BigUint<M>, // TODO: Update to contain the extra collateral after pool rebalancing,
     // used to pay out rewards to hedging agents on close position
     pub hedging_positions: Vec<u64>,
@@ -19,6 +20,7 @@ impl<M: ManagedTypeApi> Pool<M> {
             collateral_amount: BigUint::zero(api.clone()),
             stablecoin_amount: BigUint::zero(api.clone()),
             total_collateral_covered: BigUint::zero(api.clone()),
+            total_covered_value_in_stablecoin: BigUint::zero(api.clone()),
             hedging_agents_profit: BigUint::zero(api),
             hedging_positions: Vec::new(),
         }
@@ -36,8 +38,6 @@ pub trait PoolsModule:
 
         self.calculate_ratio(&total_covered, &reserves)
     }
-
-    // TODO: Pool rebalancing endpoint
 
     fn get_pool(&self, collateral_id: &TokenIdentifier) -> Pool<Self::Api> {
         if self.pool_for_collateral(collateral_id).is_empty() {
@@ -86,7 +86,7 @@ pub trait PoolsModule:
 
     fn require_collateral_in_whitelist(&self, collateral_id: &TokenIdentifier) -> SCResult<()> {
         require!(
-            self.collateral_whitelist().contains(&collateral_id),
+            self.collateral_whitelist().contains(collateral_id),
             "collateral is not whitelisted"
         );
         Ok(())

--- a/stablecoin-v2/src/pools.rs
+++ b/stablecoin-v2/src/pools.rs
@@ -17,7 +17,7 @@ impl<M: ManagedTypeApi> Pool<M> {
             collateral_amount: BigUint::zero(api.clone()),
             stablecoin_amount: BigUint::zero(api.clone()),
             total_collateral_covered: BigUint::zero(api.clone()),
-            total_covered_value_in_stablecoin: BigUint::zero(api.clone()),
+            total_covered_value_in_stablecoin: BigUint::zero(api),
         }
     }
 }
@@ -26,14 +26,6 @@ impl<M: ManagedTypeApi> Pool<M> {
 pub trait PoolsModule:
     crate::math::MathModule + price_aggregator_proxy::PriceAggregatorModule
 {
-    #[view(getCoverageRatio)]
-    fn get_coverage_ratio(&self, collateral_id: &TokenIdentifier) -> BigUint {
-        let reserves = self.get_pool_reserves(collateral_id);
-        let total_covered = self.get_pool_amount_covered(collateral_id);
-
-        self.calculate_ratio(&total_covered, &reserves)
-    }
-
     fn get_pool(&self, collateral_id: &TokenIdentifier) -> Pool<Self::Api> {
         if self.pool_for_collateral(collateral_id).is_empty() {
             Pool::new(self.raw_vm_api())

--- a/stablecoin-v2/src/pools.rs
+++ b/stablecoin-v2/src/pools.rs
@@ -7,6 +7,7 @@ use price_aggregator_proxy::DOLLAR_TICKER;
 pub struct Pool<M: ManagedTypeApi> {
     pub collateral_amount: BigUint<M>,
     pub stablecoin_amount: BigUint<M>,
+    pub total_hedging_agents_deposit: BigUint<M>,
     pub total_collateral_covered: BigUint<M>,
     pub total_covered_value_in_stablecoin: BigUint<M>,
 }
@@ -16,6 +17,7 @@ impl<M: ManagedTypeApi> Pool<M> {
         Pool {
             collateral_amount: BigUint::zero(api.clone()),
             stablecoin_amount: BigUint::zero(api.clone()),
+            total_hedging_agents_deposit: BigUint::zero(api.clone()),
             total_collateral_covered: BigUint::zero(api.clone()),
             total_covered_value_in_stablecoin: BigUint::zero(api),
         }

--- a/stablecoin-v2/src/pools.rs
+++ b/stablecoin-v2/src/pools.rs
@@ -78,9 +78,14 @@ pub trait PoolsModule:
         self.create_precision_biguint(collateral_num_decimals)
     }
 
+    #[inline(always)]
+    fn is_collateral_whitelisted(&self, collateral_id: &TokenIdentifier) -> bool {
+        self.collateral_whitelisted(collateral_id).get()
+    }
+
     fn require_collateral_in_whitelist(&self, collateral_id: &TokenIdentifier) -> SCResult<()> {
         require!(
-            self.collateral_whitelist().contains(collateral_id),
+            self.is_collateral_whitelisted(collateral_id),
             "collateral is not whitelisted"
         );
         Ok(())
@@ -88,9 +93,9 @@ pub trait PoolsModule:
 
     // storage
 
-    #[view(getCollateralWhitelist)]
-    #[storage_mapper("collateralWhitelist")]
-    fn collateral_whitelist(&self) -> SetMapper<TokenIdentifier>;
+    #[view(isCollateralWhitelisted)]
+    #[storage_mapper("collateralWhitelisted")]
+    fn collateral_whitelisted(&self, collateral_id: &TokenIdentifier) -> SingleValueMapper<bool>;
 
     #[view(getCollateralTicker)]
     #[storage_mapper("collateralTicker")]

--- a/stablecoin-v2/src/stablecoin_token.rs
+++ b/stablecoin-v2/src/stablecoin_token.rs
@@ -2,6 +2,8 @@ elrond_wasm::imports!();
 
 const STABLE_COIN_NAME: &[u8] = b"StableCoin";
 const STABLE_COIN_TICKER: &[u8] = b"STCOIN";
+const STABLE_COIN_NUM_DECIMALS: usize = 6;
+// pub const STABLE_COIN_PRECISION: u64 = 1_000_000;
 
 #[elrond_wasm::module]
 pub trait StablecoinTokenModule {
@@ -29,7 +31,7 @@ pub trait StablecoinTokenModule {
                 FungibleTokenProperties {
                     can_burn: true,
                     can_mint: true,
-                    num_decimals: 0,
+                    num_decimals: STABLE_COIN_NUM_DECIMALS,
                     can_freeze: true,
                     can_wipe: true,
                     can_pause: true,


### PR DESCRIPTION
- added the so-called "keepers" actors. Their role is mainly to liquidate/close hedging positions that are deemed too risky for the protocol or if too many positions are opened compared to the existing collateral
- added more restrictions for opening hedging positions
- hedging agents can now add/remove margin to/from their positions
- added logic to update pools when new hedging positions are added or existing ones are closed

What still needs to be done:
- checking the pool's balances when paying out hedging positions. This has not been done yet, as that requires logic to send some other token. Will be added in a future PR.
- standard liquidity provider actors
- managing the fees and splitting accordingly instead of accumulating
- emitting events when position statuses change (useful for keepers)