### PR TITLE
V2 liquidity providers

### DIFF
--- a/stablecoin-v2/src/fees.rs
+++ b/stablecoin-v2/src/fees.rs
@@ -2,6 +2,9 @@ elrond_wasm::imports!();
 
 use crate::math::ONE;
 
+// TODO: calculate fees only when rebalancing pool by keepers
+// store the value in storage instead of calculating everytime
+
 #[elrond_wasm::module]
 pub trait FeesModule:
     crate::math::MathModule + crate::pools::PoolsModule + price_aggregator_proxy::PriceAggregatorModule
@@ -91,6 +94,10 @@ pub trait FeesModule:
         self.calculate_percentage_of(&hedging_ratio_limit, collateral_amount)
     }
 
+    fn split_fees(&self) {
+        // TODO
+    }
+
     // storage
 
     #[storage_mapper("minMaxFeesPercentage")]
@@ -99,8 +106,6 @@ pub trait FeesModule:
         collateral_id: &TokenIdentifier,
     ) -> SingleValueMapper<(BigUint, BigUint)>;
 
-    // TODO: Don't accumulate here, but rather split the fees when the transaction is processed
-    // These fees will go to the liquidity providers
     #[storage_mapper("accumulatedTxFees")]
     fn accumulated_tx_fees(&self, collateral_id: &TokenIdentifier) -> SingleValueMapper<BigUint>;
 

--- a/stablecoin-v2/src/hedging_agents.rs
+++ b/stablecoin-v2/src/hedging_agents.rs
@@ -32,6 +32,7 @@ pub trait HedgingAgentsModule:
     + crate::math::MathModule
     + crate::pools::PoolsModule
     + price_aggregator_proxy::PriceAggregatorModule
+    + crate::token_common::TokenCommonModule
 {
     #[payable("*")]
     #[endpoint(openHedgingPosition)]

--- a/stablecoin-v2/src/hedging_agents.rs
+++ b/stablecoin-v2/src/hedging_agents.rs
@@ -3,9 +3,14 @@ elrond_wasm::derive_imports!();
 
 use crate::math::ONE;
 
-pub struct WithdrawAmountFeeSplit<M: ManagedTypeApi> {
+pub struct HedgerWithdrawAmountFeeSplit<M: ManagedTypeApi> {
     pub withdraw_amount: BigUint<M>,
     pub fees_amount: BigUint<M>,
+}
+
+pub struct HedgerRewardAmountsTokensPair<M: ManagedTypeApi> {
+    pub collateral_amount: BigUint<M>,
+    pub liq_tokens_amount: BigUint<M>,
 }
 
 #[derive(TypeAbi, TopEncode, TopDecode)]
@@ -29,6 +34,7 @@ impl<M: ManagedTypeApi> HedgingPosition<M> {
 pub trait HedgingAgentsModule:
     crate::fees::FeesModule
     + crate::hedging_token::HedgingTokenModule
+    + crate::liquidity_token::LiquidityTokenModule
     + crate::math::MathModule
     + crate::pools::PoolsModule
     + price_aggregator_proxy::PriceAggregatorModule
@@ -82,7 +88,7 @@ pub trait HedgingAgentsModule:
             self.calculate_percentage_of(&transaction_fees_percentage, &payment_amount);
         let collateral_amount = &payment_amount - &fees_amount_in_collateral;
 
-        pool.total_hedging_agents_deposit += &collateral_amount;
+        pool.collateral_reserves += &collateral_amount;
 
         let hedging_position = HedgingPosition {
             collateral_id: payment_token.clone(),
@@ -141,7 +147,7 @@ pub trait HedgingAgentsModule:
             Ok(())
         })?;
         self.update_pool(&second_transfer.token_identifier, |pool| {
-            pool.total_hedging_agents_deposit += &second_transfer.amount;
+            pool.collateral_reserves += &second_transfer.amount;
         });
 
         // return the nft
@@ -165,7 +171,7 @@ pub trait HedgingAgentsModule:
             "Token should be the hedging NFT"
         );
 
-        self.hedging_position(payment_nonce).update(|hedging_pos| {
+        let collateral_id = self.hedging_position(payment_nonce).update(|hedging_pos| {
             require!(
                 amount_to_remove < hedging_pos.deposit_amount,
                 "Remove amount higher than total deposit"
@@ -175,14 +181,24 @@ pub trait HedgingAgentsModule:
             hedging_pos.deposit_amount -= &amount_to_remove;
             self.require_under_max_leverage(hedging_pos)?;
 
-            Ok(())
+            Ok(hedging_pos.collateral_id.clone())
         })?;
         self.update_pool(&payment_token, |pool| {
-            pool.total_hedging_agents_deposit -= amount_to_remove;
-        });
+            require!(
+                amount_to_remove <= pool.collateral_reserves,
+                "Not enough reserves in pool"
+            );
+
+            pool.collateral_reserves -= &amount_to_remove;
+
+            Ok(())
+        })?;
+
+        let caller = self.blockchain().get_caller();
+        self.send()
+            .direct(&caller, &collateral_id, 0, &amount_to_remove, &[]);
 
         // return the nft
-        let caller = self.blockchain().get_caller();
         self.send_hedging_token(&caller, payment_nonce);
 
         Ok(())
@@ -204,24 +220,28 @@ pub trait HedgingAgentsModule:
         self.require_not_liquidated(payment_nonce)?;
 
         let hedging_position = self.hedging_position(payment_nonce).get();
-        let withdraw_amount = match hedging_position.withdraw_amount_after_force_close {
-            Some(amt) => amt,
+        let withdraw_split = match hedging_position.withdraw_amount_after_force_close {
+            Some(withdraw_amount) => self
+                .calculate_withdraw_amounts_split(&hedging_position.collateral_id, withdraw_amount),
             None => {
                 self.close_position(&hedging_position)?;
 
-                let amt = self.get_withdraw_amount_and_update_fees(
+                let withdraw_amount = self.get_withdraw_amount_and_update_fees(
                     &hedging_position,
                     Some(min_oracle_value),
                 )?;
-                self.update_pool_after_closed_position(
+                let split = self.calculate_withdraw_amounts_split(
                     &hedging_position.collateral_id,
-                    &hedging_position.deposit_amount,
-                    &amt,
+                    withdraw_amount.clone(),
                 );
 
-                amt
+                split
             }
         };
+
+        self.update_pool(&hedging_position.collateral_id, |pool| {
+            pool.collateral_reserves -= &withdraw_split.collateral_amount;
+        });
 
         self.hedging_position(payment_nonce).clear();
         self.burn_hedging_token(payment_nonce);
@@ -231,9 +251,18 @@ pub trait HedgingAgentsModule:
             &caller,
             &hedging_position.collateral_id,
             0,
-            &withdraw_amount,
+            &withdraw_split.collateral_amount,
             &[],
         );
+
+        let liq_tokens_amount = withdraw_split.liq_tokens_amount;
+        if liq_tokens_amount > 0 {
+            self.create_and_send_liq_tokens(
+                &caller,
+                &hedging_position.collateral_id,
+                &liq_tokens_amount,
+            );
+        }
 
         Ok(())
     }
@@ -286,7 +315,7 @@ pub trait HedgingAgentsModule:
         &self,
         hedging_position: &HedgingPosition<Self::Api>,
         opt_min_oracle_value: Option<BigUint>,
-    ) -> SCResult<WithdrawAmountFeeSplit<Self::Api>> {
+    ) -> SCResult<HedgerWithdrawAmountFeeSplit<Self::Api>> {
         let collateral_value_in_dollars =
             self.get_collateral_value_in_dollars(&hedging_position.collateral_id)?;
         if let Some(min_oracle_value) = opt_min_oracle_value {
@@ -324,30 +353,32 @@ pub trait HedgingAgentsModule:
             self.calculate_percentage_of(&transaction_fees_percentage, &base_withdraw_amount);
         let withdraw_amount = &base_withdraw_amount - &fees_amount;
 
-        Ok(WithdrawAmountFeeSplit {
+        Ok(HedgerWithdrawAmountFeeSplit {
             withdraw_amount,
             fees_amount,
         })
     }
 
-    fn update_pool_after_closed_position(
+    fn calculate_withdraw_amounts_split(
         &self,
         collateral_id: &TokenIdentifier,
-        deposit_amount: &BigUint,
-        withdraw_amount: &BigUint,
-    ) {
-        if withdraw_amount > deposit_amount {
-            let hedger_reward = withdraw_amount - deposit_amount;
-            self.update_pool(collateral_id, |pool| {
-                pool.total_hedging_agents_deposit -= deposit_amount;
-                pool.collateral_amount -= hedger_reward
-            });
+        full_withdraw_amount: BigUint,
+    ) -> HedgerRewardAmountsTokensPair<Self::Api> {
+        let reserves = self.get_pool_reserves(collateral_id);
+        if full_withdraw_amount <= reserves {
+            HedgerRewardAmountsTokensPair {
+                collateral_amount: full_withdraw_amount,
+                liq_tokens_amount: BigUint::zero(),
+            }
         } else {
-            let hedger_penalty = deposit_amount - withdraw_amount;
-            self.update_pool(collateral_id, |pool| {
-                pool.total_hedging_agents_deposit -= deposit_amount;
-                pool.collateral_amount += hedger_penalty
-            });
+            let collateral_amount_over_reserves = &full_withdraw_amount - &reserves;
+            let amount_in_liq_tokens =
+                self.collateral_to_liq_tokens(collateral_id, &collateral_amount_over_reserves);
+
+            HedgerRewardAmountsTokensPair {
+                collateral_amount: reserves,
+                liq_tokens_amount: amount_in_liq_tokens,
+            }
         }
     }
 

--- a/stablecoin-v2/src/keepers.rs
+++ b/stablecoin-v2/src/keepers.rs
@@ -12,6 +12,7 @@ pub trait KeepersModule:
     + crate::math::MathModule
     + crate::pools::PoolsModule
     + price_aggregator_proxy::PriceAggregatorModule
+    + crate::token_common::TokenCommonModule
 {
     #[endpoint(forceCloseHedgingPosition)]
     fn force_close_hedging_position(&self, nft_nonce: u64) -> SCResult<()> {

--- a/stablecoin-v2/src/keepers.rs
+++ b/stablecoin-v2/src/keepers.rs
@@ -2,18 +2,66 @@ elrond_wasm::imports!();
 
 use crate::{hedging_agents::HedgingPosition, math::ONE};
 
-// TODO: Pay some part of the hedging position open fees to keepers as rewards
-
 #[elrond_wasm::module]
 pub trait KeepersModule:
     crate::fees::FeesModule
     + crate::hedging_agents::HedgingAgentsModule
     + crate::hedging_token::HedgingTokenModule
+    + crate::liquidity_token::LiquidityTokenModule
     + crate::math::MathModule
     + crate::pools::PoolsModule
     + price_aggregator_proxy::PriceAggregatorModule
     + crate::token_common::TokenCommonModule
 {
+    #[endpoint(rebalancePool)]
+    fn rebalance_pool(&self, collateral_id: TokenIdentifier) -> SCResult<()> {
+        self.require_collateral_in_whitelist(&collateral_id)?;
+
+        let collateral_value_in_dollars = self.get_collateral_value_in_dollars(&collateral_id)?;
+        let collateral_precision = self.get_collateral_precision(&collateral_id);
+
+        self.update_pool(&collateral_id, |pool| {
+            let pool_value_in_dollars = self.multiply(
+                &pool.collateral_amount,
+                &collateral_value_in_dollars,
+                &collateral_precision,
+            );
+
+            // collateral value increased, so we move the extra to reserves
+            if pool_value_in_dollars > pool.stablecoin_amount {
+                let extra_collateral_in_dollars = &pool_value_in_dollars - &pool.stablecoin_amount;
+                let extra_collateral_amount = self.divide(
+                    &extra_collateral_in_dollars,
+                    &collateral_value_in_dollars,
+                    &collateral_precision,
+                );
+
+                pool.collateral_reserves += extra_collateral_amount;
+            }
+            // collateral value decreased, so we take collateral from the reserves to rebalance the pool
+            else {
+                let missing_collateral_in_dollars =
+                    &pool.stablecoin_amount - &pool_value_in_dollars;
+                let missing_collateral_amount = self.divide(
+                    &missing_collateral_in_dollars,
+                    &collateral_value_in_dollars,
+                    &collateral_precision,
+                );
+
+                require!(
+                    missing_collateral_amount <= pool.collateral_reserves,
+                    "Not enough reserves to rebalance pool"
+                );
+
+                pool.collateral_reserves -= missing_collateral_amount;
+            }
+
+            pool.stablecoin_amount = pool_value_in_dollars;
+
+            Ok(())
+        })
+    }
+
     #[endpoint(forceCloseHedgingPosition)]
     fn force_close_hedging_position(&self, nft_nonce: u64) -> SCResult<()> {
         self.require_not_liquidated(nft_nonce)?;
@@ -30,12 +78,6 @@ pub trait KeepersModule:
         self.close_position(&hedging_position)?;
 
         let withdraw_amount = self.get_withdraw_amount_and_update_fees(&hedging_position, None)?;
-        self.update_pool_after_closed_position(
-            &hedging_position.collateral_id,
-            &hedging_position.deposit_amount,
-            &withdraw_amount,
-        );
-
         hedging_position.withdraw_amount_after_force_close = Some(withdraw_amount);
         self.hedging_position(nft_nonce).set(&hedging_position);
 
@@ -59,12 +101,6 @@ pub trait KeepersModule:
         );
 
         self.close_position(&hedging_position)?;
-        self.update_pool_after_closed_position(
-            &hedging_position.collateral_id,
-            &hedging_position.deposit_amount,
-            &BigUint::zero(),
-        );
-
         self.hedging_position(nft_nonce).clear();
 
         Ok(())

--- a/stablecoin-v2/src/lib.rs
+++ b/stablecoin-v2/src/lib.rs
@@ -3,13 +3,16 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
+mod hedging_token;
+mod liquidity_token;
+mod stablecoin_token;
+mod token_common;
+
 mod fees;
 mod hedging_agents;
-mod hedging_token;
 mod keepers;
 mod math;
 mod pools;
-mod stablecoin_token;
 
 // TODO: Check pool collateral values before subtracting, give other tokens instead for leftover amounts
 // TODO: Add events
@@ -20,10 +23,12 @@ pub trait StablecoinV2:
     + hedging_agents::HedgingAgentsModule
     + hedging_token::HedgingTokenModule
     + keepers::KeepersModule
+    + liquidity_token::LiquidityTokenModule
     + math::MathModule
     + pools::PoolsModule
     + price_aggregator_proxy::PriceAggregatorModule
     + stablecoin_token::StablecoinTokenModule
+    + token_common::TokenCommonModule
 {
     #[init]
     fn init(

--- a/stablecoin-v2/src/liquidity_providers.rs
+++ b/stablecoin-v2/src/liquidity_providers.rs
@@ -1,0 +1,67 @@
+elrond_wasm::imports!();
+
+// TODO: Pay some part of the hedging position open/close fees to liquidity providers as rewards
+
+#[elrond_wasm::module]
+pub trait LiquidityProvidersModule:
+    crate::liquidity_token::LiquidityTokenModule
+    + crate::math::MathModule
+    + crate::pools::PoolsModule
+    + price_aggregator_proxy::PriceAggregatorModule
+    + crate::token_common::TokenCommonModule
+{
+    #[payable("*")]
+    #[endpoint(addLiquidity)]
+    fn add_liquidity(
+        &self,
+        #[payment_token] payment_token: TokenIdentifier,
+        #[payment_amount] payment_amount: BigUint,
+    ) -> SCResult<()> {
+        self.require_collateral_in_whitelist(&payment_token)?;
+
+        self.update_pool(&payment_token, |pool| {
+            pool.collateral_reserves += &payment_amount;
+        });
+
+        let caller = self.blockchain().get_caller();
+        let amount_in_liq_tokens = self.collateral_to_liq_tokens(&payment_token, &payment_amount);
+        self.create_and_send_liq_tokens(&caller, &payment_token, &amount_in_liq_tokens);
+
+        Ok(())
+    }
+
+    #[payable("*")]
+    #[endpoint(removeLiquidity)]
+    fn remove_liquidity(
+        &self,
+        #[payment_token] payment_token: TokenIdentifier,
+        #[payment_nonce] payment_nonce: u64,
+        #[payment_amount] payment_amount: BigUint,
+    ) -> SCResult<()> {
+        let liq_token_id = self.liquidity_token_id().get();
+        require!(
+            payment_token == liq_token_id,
+            "May only pay with liquidity SFTs"
+        );
+
+        let collateral_id = self.collateral_for_liq_sft_nonce(payment_nonce).get();
+        let amount_in_collateral = self.liq_tokens_to_collateral(&collateral_id, &payment_amount);
+
+        self.update_pool(&collateral_id, |pool| {
+            require!(
+                amount_in_collateral <= pool.collateral_reserves,
+                "Not enough reserves in pool"
+            );
+
+            pool.collateral_reserves -= &amount_in_collateral;
+
+            Ok(())
+        })?;
+
+        let caller = self.blockchain().get_caller();
+        self.send()
+            .direct(&caller, &collateral_id, 0, &amount_in_collateral, &[]);
+
+        Ok(())
+    }
+}

--- a/stablecoin-v2/src/liquidity_token.rs
+++ b/stablecoin-v2/src/liquidity_token.rs
@@ -1,0 +1,119 @@
+elrond_wasm::imports!();
+
+const LIQUIDITY_TOKEN_NAME: &[u8] = b"LiquidityToken";
+const LIQUIDITY_TOKEN_TICKER: &[u8] = b"LIQ";
+
+#[elrond_wasm::module]
+pub trait LiquidityTokenModule: crate::token_common::TokenCommonModule {
+    #[only_owner]
+    #[payable("EGLD")]
+    #[endpoint(issueLiquidityToken)]
+    fn issue_liquidity_token(&self, #[payment] issue_cost: BigUint) -> SCResult<AsyncCall> {
+        require!(
+            self.liquidity_token_id().is_empty(),
+            "Hedging token already issued"
+        );
+
+        let token_display_name = ManagedBuffer::from(LIQUIDITY_TOKEN_NAME);
+        let token_ticker = ManagedBuffer::from(LIQUIDITY_TOKEN_TICKER);
+
+        Ok(self
+            .send()
+            .esdt_system_sc_proxy()
+            .issue_semi_fungible(
+                issue_cost,
+                &token_display_name,
+                &token_ticker,
+                SemiFungibleTokenProperties {
+                    can_freeze: true,
+                    can_wipe: true,
+                    can_pause: true,
+                    can_change_owner: true,
+                    can_upgrade: true,
+                    can_add_special_roles: true,
+                },
+            )
+            .async_call()
+            .with_callback(self.callbacks().liquidity_token_issue_callback()))
+    }
+
+    #[endpoint(setLiquidityTokenRoles)]
+    fn set_liquidity_token_roles(&self) -> AsyncCall {
+        let token_id = self.liquidity_token_id().get();
+        let roles = [
+            EsdtLocalRole::NftCreate,
+            EsdtLocalRole::NftAddQuantity,
+            EsdtLocalRole::NftBurn,
+        ];
+
+        self.set_local_roles(&token_id, &roles)
+    }
+
+    fn create_or_mint_liq_tokens(&self, collateral_id: &TokenIdentifier, amount: &BigUint) -> u64 {
+        let token_id = self.liquidity_token_id().get();
+
+        let existing_sft_nonce = self.liq_sft_nonce_for_collateral(collateral_id).get();
+        if existing_sft_nonce > 0 {
+            self.send()
+                .esdt_local_mint(&token_id, existing_sft_nonce, amount);
+
+            return existing_sft_nonce;
+        }
+
+        let new_sft_nonce = self.create_nft(&token_id, amount);
+        self.liq_sft_nonce_for_collateral(collateral_id)
+            .set(&new_sft_nonce);
+        self.collateral_for_liq_sft_nonce(new_sft_nonce)
+            .set(collateral_id);
+
+        new_sft_nonce
+    }
+
+    fn send_liq_tokens(&self, to: &ManagedAddress, sft_nonce: u64, amount: &BigUint) {
+        let token_id = self.liquidity_token_id().get();
+
+        self.send().direct(to, &token_id, sft_nonce, amount, &[]);
+    }
+
+    fn burn_liq_tokens(&self, sft_nonce: u64, amount: &BigUint) {
+        let token_id = self.liquidity_token_id().get();
+
+        self.send().esdt_local_burn(&token_id, sft_nonce, amount);
+    }
+
+    #[callback]
+    fn liquidity_token_issue_callback(
+        &self,
+        #[call_result] result: ManagedAsyncCallResult<TokenIdentifier>,
+    ) -> OptionalResult<AsyncCall> {
+        match result {
+            ManagedAsyncCallResult::Ok(token_id) => {
+                self.liquidity_token_id().set(&token_id);
+
+                OptionalResult::Some(self.set_liquidity_token_roles())
+            }
+            ManagedAsyncCallResult::Err(_) => {
+                self.refund_owner_failed_issue();
+
+                OptionalResult::None
+            }
+        }
+    }
+
+    // storage
+
+    #[view(getLiquidityTokenId)]
+    #[storage_mapper("liquidityTokenId")]
+    fn liquidity_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
+
+    #[view(getLiquidityTokenSftNonceForCollateral)]
+    #[storage_mapper("liqSftNonceForCollateral")]
+    fn liq_sft_nonce_for_collateral(
+        &self,
+        collateral_id: &TokenIdentifier,
+    ) -> SingleValueMapper<u64>;
+
+    #[view(getCollateralForLiquidityTokenSftNonce)]
+    #[storage_mapper("collateralForLiqSftNonce")]
+    fn collateral_for_liq_sft_nonce(&self, sft_nonce: u64) -> SingleValueMapper<TokenIdentifier>;
+}

--- a/stablecoin-v2/src/math.rs
+++ b/stablecoin-v2/src/math.rs
@@ -15,6 +15,11 @@ pub trait MathModule {
     }
 
     #[inline(always)]
+    fn divide(&self, first: &BigUint, second: &BigUint, result_precision: &BigUint) -> BigUint {
+        &(first * result_precision) / second
+    }
+
+    #[inline(always)]
     fn calculate_ratio(&self, first: &BigUint, second: &BigUint) -> BigUint {
         &(first * ONE) / second
     }

--- a/stablecoin-v2/src/pools.rs
+++ b/stablecoin-v2/src/pools.rs
@@ -7,17 +7,17 @@ use price_aggregator_proxy::DOLLAR_TICKER;
 pub struct Pool<M: ManagedTypeApi> {
     pub collateral_amount: BigUint<M>,
     pub stablecoin_amount: BigUint<M>,
-    pub total_hedging_agents_deposit: BigUint<M>,
+    pub collateral_reserves: BigUint<M>,
     pub total_collateral_covered: BigUint<M>,
     pub total_covered_value_in_stablecoin: BigUint<M>,
 }
 
 impl<M: ManagedTypeApi> Pool<M> {
-    fn new(api: M) -> Self {
+    pub fn new(api: M) -> Self {
         Pool {
             collateral_amount: BigUint::zero(api.clone()),
             stablecoin_amount: BigUint::zero(api.clone()),
-            total_hedging_agents_deposit: BigUint::zero(api.clone()),
+            collateral_reserves: BigUint::zero(api.clone()),
             total_collateral_covered: BigUint::zero(api.clone()),
             total_covered_value_in_stablecoin: BigUint::zero(api),
         }
@@ -28,22 +28,24 @@ impl<M: ManagedTypeApi> Pool<M> {
 pub trait PoolsModule:
     crate::math::MathModule + price_aggregator_proxy::PriceAggregatorModule
 {
+    #[inline(always)]
     fn get_pool(&self, collateral_id: &TokenIdentifier) -> Pool<Self::Api> {
-        if self.pool_for_collateral(collateral_id).is_empty() {
-            Pool::new(self.raw_vm_api())
-        } else {
-            self.pool_for_collateral(collateral_id).get()
-        }
+        self.pool_for_collateral(collateral_id).get()
     }
 
     #[inline(always)]
-    fn get_pool_reserves(&self, collateral_id: &TokenIdentifier) -> BigUint {
+    fn get_pool_collateral_amount(&self, collateral_id: &TokenIdentifier) -> BigUint {
         self.get_pool(collateral_id).collateral_amount
     }
 
     #[inline(always)]
     fn get_pool_amount_covered(&self, collateral_id: &TokenIdentifier) -> BigUint {
         self.get_pool(collateral_id).total_collateral_covered
+    }
+
+    #[inline(always)]
+    fn get_pool_reserves(&self, collateral_id: &TokenIdentifier) -> BigUint {
+        self.get_pool(collateral_id).collateral_reserves
     }
 
     fn update_pool<R, F: FnOnce(&mut Pool<Self::Api>) -> R>(
@@ -71,6 +73,40 @@ pub trait PoolsModule:
         self.get_price_for_pair(collateral_ticker, ManagedBuffer::from(DOLLAR_TICKER))
             .ok_or("Could not get collateral value in dollars")
             .into()
+    }
+
+    // TODO: How to calculate this? Maybe based on accumulated fees?
+    fn get_liq_token_value_in_collateral(&self, collateral_id: &TokenIdentifier) -> BigUint {
+        // mock simply returns 1:1 ratio
+        self.get_collateral_precision(collateral_id)
+    }
+
+    fn collateral_to_liq_tokens(
+        &self,
+        collateral_id: &TokenIdentifier,
+        collateral_amount: &BigUint,
+    ) -> BigUint {
+        let liq_token_value_in_collateral = self.get_liq_token_value_in_collateral(collateral_id);
+        let collateral_precision = self.get_collateral_precision(collateral_id);
+        self.divide(
+            collateral_amount,
+            &liq_token_value_in_collateral,
+            &collateral_precision,
+        )
+    }
+
+    fn liq_tokens_to_collateral(
+        &self,
+        collateral_id: &TokenIdentifier,
+        liq_token_amount: &BigUint,
+    ) -> BigUint {
+        let liq_token_value_in_collateral = self.get_liq_token_value_in_collateral(collateral_id);
+        let collateral_precision = self.get_collateral_precision(collateral_id);
+        self.multiply(
+            liq_token_amount,
+            &liq_token_value_in_collateral,
+            &collateral_precision,
+        )
     }
 
     fn get_collateral_precision(&self, collateral_id: &TokenIdentifier) -> BigUint {

--- a/stablecoin-v2/src/token_common.rs
+++ b/stablecoin-v2/src/token_common.rs
@@ -1,0 +1,36 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait TokenCommonModule {
+    fn set_local_roles(&self, token_id: &TokenIdentifier, roles: &[EsdtLocalRole]) -> AsyncCall {
+        let own_sc_address = self.blockchain().get_sc_address();
+
+        self.send()
+            .esdt_system_sc_proxy()
+            .set_special_roles(&own_sc_address, token_id, roles.into_iter().cloned())
+            .async_call()
+    }
+
+    fn create_nft(&self, token_id: &TokenIdentifier, amount: &BigUint) -> u64 {
+        let mut uris = ManagedVec::new();
+        uris.push(ManagedBuffer::new());
+
+        self.send().esdt_nft_create(
+            token_id,
+            amount,
+            &ManagedBuffer::new(),
+            &BigUint::zero(),
+            &ManagedBuffer::new(),
+            &(),
+            &uris,
+        )
+    }
+
+    fn refund_owner_failed_issue(&self) {
+        let owner = self.blockchain().get_owner_address();
+        let egld_returned = self.call_value().egld_value();
+        if egld_returned > 0 {
+            self.send().direct_egld(&owner, &egld_returned, &[]);
+        }
+    }
+}


### PR DESCRIPTION
- add liquidity provider actors: They simply add liquidity in the reserves on the pools, receiving transaction fees from open/close hedging positions and such (The fees distribution is not done yet). They receive so-called "liquidity tokens" that can be swapped back for the deposited collateral
- add the role of rebalancing the pools to keepers
- accumulate all extra collateral in the pool's reserves instead of manually keeping track of where it comes from
- pay hedging agents in liquidity tokens if not enough reserves are available
- deduplicate some code into a generic "token module"

What still needs to be done:
- optimize fees calculation to only be done when pool is re-balanced
- split fees
- properly calculate the liquidity token's value in collateral based on accumulated fees
- lend part of the reserves to lending/borrowing style contracts
- events
- refactor code into multiple folders