### PR TITLE
V2 - fees + liq token value

### DIFF
--- a/stablecoin-v2/src/hedging_agents.rs
+++ b/stablecoin-v2/src/hedging_agents.rs
@@ -372,8 +372,9 @@ pub trait HedgingAgentsModule:
             }
         } else {
             let collateral_amount_over_reserves = &full_withdraw_amount - &reserves;
+            let collateral_precision = self.get_collateral_precision(collateral_id);
             let amount_in_liq_tokens =
-                self.collateral_to_liq_tokens(collateral_id, &collateral_amount_over_reserves);
+                self.collateral_to_liq_tokens(collateral_id, &collateral_amount_over_reserves, &collateral_precision);
 
             HedgerRewardAmountsTokensPair {
                 collateral_amount: reserves,

--- a/stablecoin-v2/src/hedging_token.rs
+++ b/stablecoin-v2/src/hedging_token.rs
@@ -38,6 +38,7 @@ pub trait HedgingTokenModule: crate::token_common::TokenCommonModule {
             .with_callback(self.callbacks().hedging_token_issue_callback()))
     }
 
+    #[only_owner]
     #[endpoint(setHedgingTokenRoles)]
     fn set_hedging_token_roles(&self) -> AsyncCall {
         let token_id = self.hedging_token_id().get();

--- a/stablecoin-v2/src/lib.rs
+++ b/stablecoin-v2/src/lib.rs
@@ -73,11 +73,19 @@ pub trait StablecoinV2:
         min_fees_percentage: BigUint,
         max_fees_percentage: BigUint,
         hedging_maintenance_ratio: BigUint,
+        liq_provider_fee_reward_percentage: BigUint,
+        min_slippage_percentage: BigUint,
+        max_slippage_percentage: BigUint,
     ) -> SCResult<()> {
         require!(
             min_fees_percentage <= max_fees_percentage
                 && max_fees_percentage < math::PERCENTAGE_PRECISION,
             "Invalid fees percentages"
+        );
+        require!(
+            min_slippage_percentage <= max_slippage_percentage
+                && max_slippage_percentage < math::PERCENTAGE_PRECISION,
+            "Invalid slippage percentages"
         );
 
         self.collateral_ticker(&collateral_id)
@@ -89,6 +97,10 @@ pub trait StablecoinV2:
             .set(&(min_fees_percentage, max_fees_percentage));
         self.hedging_maintenance_ratio(&collateral_id)
             .set(&hedging_maintenance_ratio);
+        self.liq_provider_fee_reward_percentage(&collateral_id)
+            .set(&liq_provider_fee_reward_percentage);
+        self.min_max_slippage_percentage(&collateral_id)
+            .set(&(min_slippage_percentage, max_slippage_percentage));
         self.collateral_whitelisted(&collateral_id).set(&true);
 
         // preserve the pool info if it was added, removed, and then added again
@@ -106,6 +118,9 @@ pub trait StablecoinV2:
         self.max_leverage(&collateral_id).clear();
         self.min_max_fees_percentage(&collateral_id).clear();
         self.hedging_maintenance_ratio(&collateral_id).clear();
+        self.liq_provider_fee_reward_percentage(&collateral_id)
+            .clear();
+        self.min_max_slippage_percentage(&collateral_id).clear();
         self.collateral_whitelisted(&collateral_id).clear();
     }
 

--- a/stablecoin-v2/src/liquidity_providers.rs
+++ b/stablecoin-v2/src/liquidity_providers.rs
@@ -1,10 +1,11 @@
-elrond_wasm::imports!();
+use crate::math::ONE;
 
-// TODO: Pay some part of the hedging position open/close fees to liquidity providers as rewards
+elrond_wasm::imports!();
 
 #[elrond_wasm::module]
 pub trait LiquidityProvidersModule:
-    crate::liquidity_token::LiquidityTokenModule
+    crate::fees::FeesModule
+    + crate::liquidity_token::LiquidityTokenModule
     + crate::math::MathModule
     + crate::pools::PoolsModule
     + price_aggregator_proxy::PriceAggregatorModule
@@ -23,9 +24,16 @@ pub trait LiquidityProvidersModule:
             pool.collateral_reserves += &payment_amount;
         });
 
+        let collateral_precision = self.get_collateral_precision(&payment_token);
+        let amount_in_liq_tokens =
+            self.collateral_to_liq_tokens(&payment_token, &payment_amount, &collateral_precision);
+        let sft_nonce = self.create_or_mint_liq_tokens(&payment_token, &amount_in_liq_tokens);
+
+        self.collateral_amount_for_liq_token(sft_nonce)
+            .update(|collateral_amount| *collateral_amount += &payment_amount);
+
         let caller = self.blockchain().get_caller();
-        let amount_in_liq_tokens = self.collateral_to_liq_tokens(&payment_token, &payment_amount);
-        self.create_and_send_liq_tokens(&caller, &payment_token, &amount_in_liq_tokens);
+        self.send_liq_tokens(&caller, sft_nonce, &amount_in_liq_tokens);
 
         Ok(())
     }
@@ -45,23 +53,83 @@ pub trait LiquidityProvidersModule:
         );
 
         let collateral_id = self.collateral_for_liq_sft_nonce(payment_nonce).get();
-        let amount_in_collateral = self.liq_tokens_to_collateral(&collateral_id, &payment_amount);
+        let collateral_precision = self.get_collateral_precision(&collateral_id);
+        let amount_in_collateral =
+            self.liq_tokens_to_collateral(&collateral_id, &payment_amount, &collateral_precision);
+
+        let slippage_percentage = self.calculate_slippage_percentage(&collateral_id);
+        let slippage_amount_in_collateral =
+            self.calculate_percentage_of(&slippage_percentage, &amount_in_collateral);
+
+        let collateral_amount_after_slippage =
+            &amount_in_collateral - &slippage_amount_in_collateral;
 
         self.update_pool(&collateral_id, |pool| {
             require!(
-                amount_in_collateral <= pool.collateral_reserves,
+                collateral_amount_after_slippage <= pool.collateral_reserves,
                 "Not enough reserves in pool"
             );
 
-            pool.collateral_reserves -= &amount_in_collateral;
+            pool.collateral_reserves -= &collateral_amount_after_slippage;
 
             Ok(())
         })?;
 
+        self.burn_liq_tokens(payment_nonce, &payment_amount);
+        // have to deduct amount without slippage here to mantain the liq token price
+        self.collateral_amount_for_liq_token(payment_nonce)
+            .update(|collateral_amount| *collateral_amount -= &amount_in_collateral);
+
         let caller = self.blockchain().get_caller();
-        self.send()
-            .direct(&caller, &collateral_id, 0, &amount_in_collateral, &[]);
+        self.send().direct(
+            &caller,
+            &collateral_id,
+            0,
+            &collateral_amount_after_slippage,
+            &[],
+        );
 
         Ok(())
     }
+
+    #[view(getLiquidityTokenValueInCollateral)]
+    fn get_liquidity_token_value_in_collateral_view(
+        &self,
+        collateral_id: TokenIdentifier,
+    ) -> BigUint {
+        let collateral_precision = self.get_collateral_precision(&collateral_id);
+        self.get_liq_token_value_in_collateral(&collateral_id, &collateral_precision)
+    }
+
+    #[view(getSlippagePercentage)]
+    fn calculate_slippage_percentage(&self, collateral_id: &TokenIdentifier) -> BigUint {
+        let hedging_ratio = self.get_current_hedging_ratio(collateral_id);
+        let one = BigUint::from(ONE);
+
+        // no slippage if all collateral is covered
+        if hedging_ratio >= one {
+            return BigUint::zero();
+        }
+
+        let (min_slippage_percentage, max_slippage_percentage) =
+            self.min_max_slippage_percentage(collateral_id).get();
+        let percentage_diff = &max_slippage_percentage - &min_slippage_percentage;
+
+        // min + (max - min) * hedging_ratio
+        min_slippage_percentage + self.multiply(&hedging_ratio, &percentage_diff, &one)
+    }
+
+    #[storage_mapper("minMaxSlippagePercentage")]
+    fn min_max_slippage_percentage(
+        &self,
+        collateral_id: &TokenIdentifier,
+    ) -> SingleValueMapper<(BigUint, BigUint)>;
+
+    #[storage_mapper("liquidityProviderFeeRewardPercentage")]
+    fn liq_provider_fee_reward_percentage(
+        &self,
+        collateral_id: &TokenIdentifier,
+    ) -> SingleValueMapper<BigUint>;
+
+    // TODO: Configurable parameter for lending rewards percentage for SLPs
 }

--- a/stablecoin-v2/src/pools.rs
+++ b/stablecoin-v2/src/pools.rs
@@ -48,16 +48,13 @@ pub trait PoolsModule:
         self.get_pool(collateral_id).collateral_reserves
     }
 
+    #[inline(always)]
     fn update_pool<R, F: FnOnce(&mut Pool<Self::Api>) -> R>(
         &self,
         collateral_id: &TokenIdentifier,
         f: F,
     ) -> R {
-        let mut pool = self.get_pool(collateral_id);
-        let result = f(&mut pool);
-        self.pool_for_collateral(collateral_id).set(&pool);
-
-        result
+        self.pool_for_collateral(collateral_id).update(f)
     }
 
     #[inline(always)]
@@ -73,40 +70,6 @@ pub trait PoolsModule:
         self.get_price_for_pair(collateral_ticker, ManagedBuffer::from(DOLLAR_TICKER))
             .ok_or("Could not get collateral value in dollars")
             .into()
-    }
-
-    // TODO: How to calculate this? Maybe based on accumulated fees?
-    fn get_liq_token_value_in_collateral(&self, collateral_id: &TokenIdentifier) -> BigUint {
-        // mock simply returns 1:1 ratio
-        self.get_collateral_precision(collateral_id)
-    }
-
-    fn collateral_to_liq_tokens(
-        &self,
-        collateral_id: &TokenIdentifier,
-        collateral_amount: &BigUint,
-    ) -> BigUint {
-        let liq_token_value_in_collateral = self.get_liq_token_value_in_collateral(collateral_id);
-        let collateral_precision = self.get_collateral_precision(collateral_id);
-        self.divide(
-            collateral_amount,
-            &liq_token_value_in_collateral,
-            &collateral_precision,
-        )
-    }
-
-    fn liq_tokens_to_collateral(
-        &self,
-        collateral_id: &TokenIdentifier,
-        liq_token_amount: &BigUint,
-    ) -> BigUint {
-        let liq_token_value_in_collateral = self.get_liq_token_value_in_collateral(collateral_id);
-        let collateral_precision = self.get_collateral_precision(collateral_id);
-        self.multiply(
-            liq_token_amount,
-            &liq_token_value_in_collateral,
-            &collateral_precision,
-        )
     }
 
     fn get_collateral_precision(&self, collateral_id: &TokenIdentifier) -> BigUint {

--- a/stablecoin-v2/src/stablecoin_token.rs
+++ b/stablecoin-v2/src/stablecoin_token.rs
@@ -44,6 +44,7 @@ pub trait StablecoinTokenModule: crate::token_common::TokenCommonModule {
             .with_callback(self.callbacks().stablecoin_issue_callback()))
     }
 
+    #[only_owner]
     #[endpoint(setStablecoinRoles)]
     fn set_stablecoin_roles(&self) -> AsyncCall {
         let token_id = self.stablecoin_token_id().get();


### PR DESCRIPTION
This PR continues the liquidity providers one by adding the following:
- optimize fees calculation to only be done when pool is re-balanced
- split fees
- properly calculate the liquidity token's value in collateral based on accumulated fees

What still needs to be done:
- lend part of the reserves to lending/borrowing style contracts
- add events
- refactor code into multiple folders